### PR TITLE
Initialize Flutter order queue skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Churrasquinho App
+
+Este repositório contém um esqueleto de aplicativo Flutter para controle de pedidos de espetinhos.
+Inclui filas de pedidos, alteração de status (entregue e pago) e armazenamento local em SQLite.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'screens/order_queue_screen.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Churrasquinho App',
+      theme: ThemeData(primarySwatch: Colors.deepOrange),
+      home: const OrderQueueScreen(),
+    );
+  }
+}

--- a/lib/models/customer.dart
+++ b/lib/models/customer.dart
@@ -1,0 +1,19 @@
+class Customer {
+  int? id;
+  final String name;
+  final String phone;
+
+  Customer({this.id, required this.name, required this.phone});
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'name': name,
+        'phone': phone,
+      };
+
+  static Customer fromMap(Map<String, dynamic> map) => Customer(
+        id: map['id'] as int?,
+        name: map['name'] as String,
+        phone: map['phone'] as String,
+      );
+}

--- a/lib/models/order.dart
+++ b/lib/models/order.dart
@@ -1,0 +1,39 @@
+enum OrderStatus { pending, delivered, paid }
+
+class Order {
+  int? id;
+  final String customerName;
+  final List<String> items;
+  final int quantity;
+  OrderStatus status;
+  final DateTime createdAt;
+
+  Order({
+    this.id,
+    required this.customerName,
+    required this.items,
+    required this.quantity,
+    this.status = OrderStatus.pending,
+    DateTime? createdAt,
+  }) : createdAt = createdAt ?? DateTime.now();
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'customerName': customerName,
+        'items': items.join(','),
+        'quantity': quantity,
+        'status': status.index,
+        'createdAt': createdAt.toIso8601String(),
+      };
+
+  static Order fromMap(Map<String, dynamic> map) {
+    return Order(
+      id: map['id'] as int?,
+      customerName: map['customerName'] as String,
+      items: (map['items'] as String).split(','),
+      quantity: map['quantity'] as int,
+      status: OrderStatus.values[map['status'] as int],
+      createdAt: DateTime.parse(map['createdAt'] as String),
+    );
+  }
+}

--- a/lib/screens/order_queue_screen.dart
+++ b/lib/screens/order_queue_screen.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import '../models/order.dart';
+import '../services/order_service.dart';
+
+class OrderQueueScreen extends StatefulWidget {
+  const OrderQueueScreen({Key? key}) : super(key: key);
+
+  @override
+  State<OrderQueueScreen> createState() => _OrderQueueScreenState();
+}
+
+class _OrderQueueScreenState extends State<OrderQueueScreen> {
+  final OrderService _service = OrderService();
+  final TextEditingController _customerController = TextEditingController();
+  final TextEditingController _itemController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _service.init();
+  }
+
+  void _addOrder() async {
+    if (_customerController.text.isEmpty || _itemController.text.isEmpty) return;
+    final order = Order(
+      customerName: _customerController.text,
+      items: [_itemController.text],
+      quantity: 1,
+    );
+    await _service.addOrder(order);
+    setState(() {
+      _customerController.clear();
+      _itemController.clear();
+    });
+  }
+
+  void _updateStatus(Order order, OrderStatus status) async {
+    await _service.updateOrderStatus(order.id!, status);
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final orders = _service.pendingOrders;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Fila de Pedidos')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _customerController,
+                    decoration: const InputDecoration(labelText: 'Cliente'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: TextField(
+                    controller: _itemController,
+                    decoration: const InputDecoration(labelText: 'Espeto'),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.add),
+                  onPressed: _addOrder,
+                )
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: orders.length,
+              itemBuilder: (context, index) {
+                final order = orders[index];
+                return ListTile(
+                  title: Text(order.customerName),
+                  subtitle: Text(order.items.join(', ')),
+                  trailing: PopupMenuButton<OrderStatus>(
+                    onSelected: (status) => _updateStatus(order, status),
+                    itemBuilder: (context) => [
+                      const PopupMenuItem(
+                        value: OrderStatus.delivered,
+                        child: Text('Marcar como entregue'),
+                      ),
+                      const PopupMenuItem(
+                        value: OrderStatus.paid,
+                        child: Text('Marcar como pago'),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -1,0 +1,39 @@
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+
+import '../models/order.dart';
+
+class DatabaseService {
+  Database? _db;
+
+  Future<void> init() async {
+    final documents = await getApplicationDocumentsDirectory();
+    final path = join(documents.path, 'churrasquinho.db');
+    _db = await openDatabase(path, version: 1, onCreate: (db, version) {
+      db.execute('''
+        CREATE TABLE orders(
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          customerName TEXT,
+          items TEXT,
+          quantity INTEGER,
+          status INTEGER,
+          createdAt TEXT
+        )
+      ''');
+    });
+  }
+
+  Future<int> insertOrder(Order order) async {
+    return await _db!.insert('orders', order.toMap());
+  }
+
+  Future<List<Order>> fetchOrders() async {
+    final maps = await _db!.query('orders', orderBy: 'createdAt ASC');
+    return maps.map((m) => Order.fromMap(m)).toList();
+  }
+
+  Future<void> updateOrder(Order order) async {
+    await _db!.update('orders', order.toMap(), where: 'id = ?', whereArgs: [order.id]);
+  }
+}

--- a/lib/services/order_service.dart
+++ b/lib/services/order_service.dart
@@ -1,0 +1,31 @@
+import '../models/order.dart';
+import 'database_service.dart';
+
+class OrderService {
+  final DatabaseService _db = DatabaseService();
+  final List<Order> _orders = [];
+
+  Future<void> init() async {
+    await _db.init();
+    _orders.clear();
+    _orders.addAll(await _db.fetchOrders());
+  }
+
+  List<Order> get pendingOrders =>
+      _orders.where((o) => o.status == OrderStatus.pending).toList();
+
+  Future<void> addOrder(Order order) async {
+    final id = await _db.insertOrder(order);
+    order.id = id;
+    _orders.add(order);
+  }
+
+  Future<void> updateOrderStatus(int id, OrderStatus status) async {
+    final index = _orders.indexWhere((o) => o.id == id);
+    if (index != -1) {
+      final order = _orders[index];
+      order.status = status;
+      await _db.updateOrder(order);
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,19 @@
+name: churrasquinho_app
+description: App para controle de pedidos de espetinhos.
+version: 0.1.0
+
+environment:
+  sdk: ">=2.17.6 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  sqflite: ^2.0.0+4
+  path_provider: ^2.0.11
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/readme
+++ b/readme
@@ -1,1 +1,0 @@
-starting


### PR DESCRIPTION
## Summary
- initialize Flutter skeleton
- add order queue screen with status updates
- set up basic models and services
- add pubspec

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879a10d79d4832d92bea4d7f59446f1