### PR TITLE
Add item management feature

### DIFF
--- a/lib/models/menu_item.dart
+++ b/lib/models/menu_item.dart
@@ -1,0 +1,19 @@
+class MenuItem {
+  int? id;
+  final String name;
+  final String type; // 'espetinho' or 'bebida'
+
+  MenuItem({this.id, required this.name, required this.type});
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'name': name,
+        'type': type,
+      };
+
+  static MenuItem fromMap(Map<String, dynamic> map) => MenuItem(
+        id: map['id'] as int?,
+        name: map['name'] as String,
+        type: map['type'] as String,
+      );
+}

--- a/lib/screens/item_management_screen.dart
+++ b/lib/screens/item_management_screen.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import '../models/menu_item.dart';
+import '../services/menu_service.dart';
+
+class ItemManagementScreen extends StatefulWidget {
+  const ItemManagementScreen({Key? key}) : super(key: key);
+
+  @override
+  State<ItemManagementScreen> createState() => _ItemManagementScreenState();
+}
+
+class _ItemManagementScreenState extends State<ItemManagementScreen> {
+  final MenuService _service = MenuService();
+  final TextEditingController _nameController = TextEditingController();
+  String _selectedType = 'espetinho';
+
+  @override
+  void initState() {
+    super.initState();
+    _service.init();
+  }
+
+  void _addItem() async {
+    if (_nameController.text.isEmpty) return;
+    final item = MenuItem(name: _nameController.text, type: _selectedType);
+    await _service.addItem(item);
+    setState(() {
+      _nameController.clear();
+    });
+  }
+
+  void _updateItem(MenuItem item, String name) async {
+    final updated = MenuItem(id: item.id, name: name, type: item.type);
+    await _service.updateItem(updated);
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final items = _service.items;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Itens do Card\u00e1pio')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _nameController,
+                    decoration: const InputDecoration(labelText: 'Nome'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                DropdownButton<String>(
+                  value: _selectedType,
+                  items: const [
+                    DropdownMenuItem(value: 'espetinho', child: Text('Espetinho')),
+                    DropdownMenuItem(value: 'bebida', child: Text('Bebida')),
+                  ],
+                  onChanged: (value) {
+                    if (value != null) {
+                      setState(() => _selectedType = value);
+                    }
+                  },
+                ),
+                IconButton(
+                  icon: const Icon(Icons.add),
+                  onPressed: _addItem,
+                )
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: items.length,
+              itemBuilder: (context, index) {
+                final item = items[index];
+                final controller = TextEditingController(text: item.name);
+                return ListTile(
+                  title: TextField(
+                    controller: controller,
+                    decoration: const InputDecoration(border: InputBorder.none),
+                    onSubmitted: (value) {
+                      if (value.isNotEmpty) {
+                        _updateItem(item, value);
+                      }
+                    },
+                  ),
+                  subtitle: Text(item.type),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/order_queue_screen.dart
+++ b/lib/screens/order_queue_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/order.dart';
 import '../services/order_service.dart';
+import 'item_management_screen.dart';
 
 class OrderQueueScreen extends StatefulWidget {
   const OrderQueueScreen({Key? key}) : super(key: key);
@@ -43,7 +44,22 @@ class _OrderQueueScreenState extends State<OrderQueueScreen> {
   Widget build(BuildContext context) {
     final orders = _service.pendingOrders;
     return Scaffold(
-      appBar: AppBar(title: const Text('Fila de Pedidos')),
+      appBar: AppBar(
+        title: const Text('Fila de Pedidos'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.list),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const ItemManagementScreen(),
+                ),
+              );
+            },
+          )
+        ],
+      ),
       body: Column(
         children: [
           Padding(

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -3,6 +3,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:sqflite/sqflite.dart';
 
 import '../models/order.dart';
+import '../models/menu_item.dart';
 
 class DatabaseService {
   Database? _db;
@@ -10,18 +11,40 @@ class DatabaseService {
   Future<void> init() async {
     final documents = await getApplicationDocumentsDirectory();
     final path = join(documents.path, 'churrasquinho.db');
-    _db = await openDatabase(path, version: 1, onCreate: (db, version) {
-      db.execute('''
-        CREATE TABLE orders(
-          id INTEGER PRIMARY KEY AUTOINCREMENT,
-          customerName TEXT,
-          items TEXT,
-          quantity INTEGER,
-          status INTEGER,
-          createdAt TEXT
-        )
-      ''');
-    });
+    _db = await openDatabase(
+      path,
+      version: 2,
+      onCreate: (db, version) {
+        db.execute('''
+          CREATE TABLE orders(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            customerName TEXT,
+            items TEXT,
+            quantity INTEGER,
+            status INTEGER,
+            createdAt TEXT
+          )
+        ''');
+        db.execute('''
+          CREATE TABLE items(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT,
+            type TEXT
+          )
+        ''');
+      },
+      onUpgrade: (db, oldVersion, newVersion) async {
+        if (oldVersion < 2) {
+          await db.execute('''
+            CREATE TABLE items(
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              name TEXT,
+              type TEXT
+            )
+          ''');
+        }
+      },
+    );
   }
 
   Future<int> insertOrder(Order order) async {
@@ -35,5 +58,18 @@ class DatabaseService {
 
   Future<void> updateOrder(Order order) async {
     await _db!.update('orders', order.toMap(), where: 'id = ?', whereArgs: [order.id]);
+  }
+
+  Future<int> insertMenuItem(MenuItem item) async {
+    return await _db!.insert('items', item.toMap());
+  }
+
+  Future<List<MenuItem>> fetchMenuItems() async {
+    final maps = await _db!.query('items', orderBy: 'name ASC');
+    return maps.map((m) => MenuItem.fromMap(m)).toList();
+  }
+
+  Future<void> updateMenuItem(MenuItem item) async {
+    await _db!.update('items', item.toMap(), where: 'id = ?', whereArgs: [item.id]);
   }
 }

--- a/lib/services/menu_service.dart
+++ b/lib/services/menu_service.dart
@@ -1,0 +1,29 @@
+import '../models/menu_item.dart';
+import 'database_service.dart';
+
+class MenuService {
+  final DatabaseService _db = DatabaseService();
+  final List<MenuItem> _items = [];
+
+  Future<void> init() async {
+    await _db.init();
+    _items.clear();
+    _items.addAll(await _db.fetchMenuItems());
+  }
+
+  List<MenuItem> get items => List.unmodifiable(_items);
+
+  Future<void> addItem(MenuItem item) async {
+    final id = await _db.insertMenuItem(item);
+    item.id = id;
+    _items.add(item);
+  }
+
+  Future<void> updateItem(MenuItem item) async {
+    await _db.updateMenuItem(item);
+    final index = _items.indexWhere((i) => i.id == item.id);
+    if (index != -1) {
+      _items[index] = item;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `MenuItem` model to represent skewer and beverage names
- support storing menu items in `DatabaseService`
- create `MenuService` and `ItemManagementScreen` for CRUD
- link `OrderQueueScreen` to `ItemManagementScreen`

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879a3d63034832d878dd8ce75ad3c36