### PR TITLE
Standardize dates as dd/MM/yyyy

### DIFF
--- a/lib/models/order.dart
+++ b/lib/models/order.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart';
+
 enum OrderStatus { pending, delivered, paid }
 
 class Order {
@@ -17,13 +19,16 @@ class Order {
     DateTime? createdAt,
   }) : createdAt = createdAt ?? DateTime.now();
 
+  static final DateFormat _slashFormat = DateFormat('dd/MM/yyyy');
+  static final DateFormat _dashFormat = DateFormat('dd-MM-yyyy');
+
   Map<String, dynamic> toMap() => {
         'id': id,
         'customerName': customerName,
         'items': items.join(','),
         'quantity': quantity,
         'status': status.index,
-        'createdAt': createdAt.toIso8601String(),
+        'createdAt': _slashFormat.format(createdAt),
       };
 
   static Order fromMap(Map<String, dynamic> map) {
@@ -33,7 +38,14 @@ class Order {
       items: (map['items'] as String).split(','),
       quantity: map['quantity'] as int,
       status: OrderStatus.values[map['status'] as int],
-      createdAt: DateTime.parse(map['createdAt'] as String),
+      createdAt: _parseDate(map['createdAt'] as String),
     );
+  }
+
+  static DateTime _parseDate(String value) {
+    if (value.contains('-')) {
+      return _dashFormat.parse(value);
+    }
+    return _slashFormat.parse(value);
   }
 }

--- a/lib/screens/order_queue_screen.dart
+++ b/lib/screens/order_queue_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
+import 'package:intl/intl.dart';
 import '../models/order.dart';
 import '../services/order_service.dart';
 import 'item_management_screen.dart';
@@ -14,6 +16,8 @@ class _OrderQueueScreenState extends State<OrderQueueScreen> {
   final OrderService _service = OrderService();
   final TextEditingController _customerController = TextEditingController();
   final TextEditingController _itemController = TextEditingController();
+  final TextEditingController _dateController = TextEditingController();
+  final _dateMask = MaskTextInputFormatter(mask: '##/##/####');
 
   @override
   void initState() {
@@ -22,22 +26,35 @@ class _OrderQueueScreenState extends State<OrderQueueScreen> {
   }
 
   void _addOrder() async {
-    if (_customerController.text.isEmpty || _itemController.text.isEmpty) return;
+    if (_customerController.text.isEmpty ||
+        _itemController.text.isEmpty ||
+        _dateController.text.isEmpty) return;
     final order = Order(
       customerName: _customerController.text,
       items: [_itemController.text],
       quantity: 1,
+      createdAt: _parseDate(_dateController.text),
     );
     await _service.addOrder(order);
     setState(() {
       _customerController.clear();
       _itemController.clear();
+      _dateController.clear();
     });
   }
 
   void _updateStatus(Order order, OrderStatus status) async {
     await _service.updateOrderStatus(order.id!, status);
     setState(() {});
+  }
+
+  DateTime _parseDate(String value) {
+    final slash = DateFormat('dd/MM/yyyy');
+    final dash = DateFormat('dd-MM-yyyy');
+    if (value.contains('-')) {
+      return dash.parse(value);
+    }
+    return slash.parse(value);
   }
 
   @override
@@ -79,6 +96,17 @@ class _OrderQueueScreenState extends State<OrderQueueScreen> {
                     decoration: const InputDecoration(labelText: 'Espeto'),
                   ),
                 ),
+                const SizedBox(width: 8),
+                SizedBox(
+                  width: 110,
+                  child: TextField(
+                    controller: _dateController,
+                    inputFormatters: [_dateMask],
+                    keyboardType: TextInputType.number,
+                    decoration:
+                        const InputDecoration(labelText: 'Data'),
+                  ),
+                ),
                 IconButton(
                   icon: const Icon(Icons.add),
                   onPressed: _addOrder,
@@ -93,7 +121,8 @@ class _OrderQueueScreenState extends State<OrderQueueScreen> {
                 final order = orders[index];
                 return ListTile(
                   title: Text(order.customerName),
-                  subtitle: Text(order.items.join(', ')),
+                  subtitle: Text(
+                      "${order.items.join(', ')} - ${DateFormat('dd/MM/yyyy').format(order.createdAt)}"),
                   trailing: PopupMenuButton<OrderStatus>(
                     onSelected: (status) => _updateStatus(order, status),
                     itemBuilder: (context) => [

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -52,7 +52,7 @@ class DatabaseService {
   }
 
   Future<List<Order>> fetchOrders() async {
-    final maps = await _db!.query('orders', orderBy: 'createdAt ASC');
+    final maps = await _db!.query('orders', orderBy: 'id ASC');
     return maps.map((m) => Order.fromMap(m)).toList();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,8 @@ dependencies:
     sdk: flutter
   sqflite: ^2.0.0+4
   path_provider: ^2.0.11
+  intl: ^0.17.0
+  mask_text_input_formatter: ^2.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add date formatting dependencies
- store and read dates in dd/MM/yyyy format
- add masked date input when creating orders
- show order date in queue list
- order DB results by id instead of createdAt

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eb80a5e48832db93689e74b3460e7