### PR TITLE
Add multi-tenant backend skeleton and frontend pages

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "churrasco-backend",
+  "version": "1.0.0",
+  "main": "dist/app.js",
+  "license": "MIT",
+  "scripts": {
+    "start": "ts-node src/app.ts"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "pg": "^8.11.0",
+    "reflect-metadata": "^0.1.13",
+    "slugify": "^1.6.6",
+    "typeorm": "^0.3.20"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,0 +1,61 @@
+DO $$
+BEGIN
+   IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'churrasco') THEN
+      PERFORM dblink_exec('dbname=postgres', 'CREATE DATABASE churrasco');
+   END IF;
+EXCEPTION WHEN undefined_table THEN
+   -- dblink not installed, skip automatic database creation
+END$$;
+
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  full_name TEXT NOT NULL,
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  phone TEXT NOT NULL,
+  address TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS stores (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug TEXT UNIQUE NOT NULL,
+  name TEXT NOT NULL,
+  owner_id UUID NOT NULL REFERENCES users(id),
+  is_open BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE TABLE IF NOT EXISTS store_settings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  store_id UUID UNIQUE NOT NULL REFERENCES stores(id),
+  logo_url TEXT,
+  primary_color TEXT NOT NULL DEFAULT '#cc0000',
+  secondary_color TEXT
+);
+
+CREATE TABLE IF NOT EXISTS products (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  store_id UUID NOT NULL REFERENCES stores(id),
+  name TEXT NOT NULL,
+  price NUMERIC(10,2) NOT NULL,
+  category TEXT,
+  image_url TEXT
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  store_id UUID NOT NULL REFERENCES stores(id),
+  customer_name TEXT NOT NULL,
+  customer_phone TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS order_items (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id UUID NOT NULL REFERENCES orders(id),
+  product_id UUID NOT NULL REFERENCES products(id),
+  quantity INT NOT NULL,
+  price NUMERIC(10,2) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_products_store ON products(store_id);
+CREATE INDEX IF NOT EXISTS idx_orders_store ON orders(store_id);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,23 @@
+import express from 'express';
+import cors from 'cors';
+import router from './routes';
+import { initializeDatabase } from './config/database';
+import { env } from './config/env';
+
+export const createApp = async () => {
+  await initializeDatabase();
+  const app = express();
+  app.use(cors());
+  app.use(express.json());
+  app.use(router);
+  return app;
+};
+
+export const startServer = async () => {
+  const app = await createApp();
+  app.listen(env.port, () => console.log(`API running on port ${env.port}`));
+};
+
+if (require.main === module) {
+  startServer();
+}

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -1,0 +1,23 @@
+import { DataSource } from 'typeorm';
+import { env } from './env';
+import { User } from '../entities/User';
+import { Store } from '../entities/Store';
+import { StoreSettings } from '../entities/StoreSettings';
+import { Product } from '../entities/Product';
+import { Order } from '../entities/Order';
+import { OrderItem } from '../entities/OrderItem';
+
+export const AppDataSource = new DataSource({
+  type: 'postgres',
+  url: env.databaseUrl,
+  entities: [User, Store, StoreSettings, Product, Order, OrderItem],
+  synchronize: false,
+  logging: false,
+});
+
+export const initializeDatabase = async () => {
+  if (!AppDataSource.isInitialized) {
+    await AppDataSource.initialize();
+  }
+  return AppDataSource;
+};

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,6 @@
+import 'dotenv/config';
+
+export const env = {
+  databaseUrl: process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/churrasco',
+  port: Number(process.env.PORT) || 3000,
+};

--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -1,0 +1,29 @@
+import { Request, Response } from 'express';
+import { AuthService } from '../services/AuthService';
+import { StoreService } from '../services/StoreService';
+
+const authService = new AuthService();
+const storeService = new StoreService();
+
+export class AuthController {
+  async register(req: Request, res: Response) {
+    try {
+      const user = await authService.register(req.body);
+      const store = await storeService.create(user.id, {
+        name: req.body.storeName,
+        logoUrl: req.body.logoUrl,
+        primaryColor: req.body.primaryColor,
+        secondaryColor: req.body.secondaryColor,
+      });
+      res.status(201).json({ user, store });
+    } catch (error) {
+      res.status(400).json({ message: 'Registration failed', error });
+    }
+  }
+
+  async login(req: Request, res: Response) {
+    const user = await authService.findByEmail(req.body.email);
+    if (!user) return res.status(401).json({ message: 'Invalid credentials' });
+    res.json({ user });
+  }
+}

--- a/backend/src/controllers/OrderController.ts
+++ b/backend/src/controllers/OrderController.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import { OrderService } from '../services/OrderService';
+
+const orderService = new OrderService();
+
+export class OrderController {
+  async create(req: Request, res: Response) {
+    const order = await orderService.create(req.params.storeId, req.body);
+    res.status(201).json(order);
+  }
+
+  async list(req: Request, res: Response) {
+    const orders = await orderService.list(req.params.storeId);
+    res.json(orders);
+  }
+}

--- a/backend/src/controllers/ProductController.ts
+++ b/backend/src/controllers/ProductController.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import { ProductService } from '../services/ProductService';
+
+const productService = new ProductService();
+
+export class ProductController {
+  async create(req: Request, res: Response) {
+    const product = await productService.create(req.params.storeId, req.body);
+    res.status(201).json(product);
+  }
+
+  async list(req: Request, res: Response) {
+    const products = await productService.listByStore(req.params.storeId);
+    res.json(products);
+  }
+}

--- a/backend/src/controllers/StoreController.ts
+++ b/backend/src/controllers/StoreController.ts
@@ -1,0 +1,22 @@
+import { Request, Response } from 'express';
+import { StoreService } from '../services/StoreService';
+
+const storeService = new StoreService();
+
+export class StoreController {
+  async getBySlug(req: Request, res: Response) {
+    const store = await storeService.findBySlug(req.params.slug);
+    if (!store) return res.status(404).json({ message: 'Store not found' });
+    res.json(store);
+  }
+
+  async update(req: Request, res: Response) {
+    const store = await storeService.update(req.params.id, req.body);
+    res.json(store);
+  }
+
+  async setStatus(req: Request, res: Response) {
+    const store = await storeService.toggleStatus(req.params.id, req.body.isOpen);
+    res.json(store);
+  }
+}

--- a/backend/src/dto/CreateOrderDto.ts
+++ b/backend/src/dto/CreateOrderDto.ts
@@ -1,0 +1,8 @@
+export interface CreateOrderDto {
+  customerName: string;
+  customerPhone?: string;
+  items: Array<{
+    productId: string;
+    quantity: number;
+  }>;
+}

--- a/backend/src/dto/CreateProductDto.ts
+++ b/backend/src/dto/CreateProductDto.ts
@@ -1,0 +1,6 @@
+export interface CreateProductDto {
+  name: string;
+  price: number;
+  category?: string;
+  imageUrl?: string;
+}

--- a/backend/src/dto/CreateStoreDto.ts
+++ b/backend/src/dto/CreateStoreDto.ts
@@ -1,0 +1,7 @@
+export interface CreateStoreDto {
+  name: string;
+  slug?: string;
+  logoUrl?: string;
+  primaryColor: string;
+  secondaryColor?: string;
+}

--- a/backend/src/dto/CreateUserDto.ts
+++ b/backend/src/dto/CreateUserDto.ts
@@ -1,0 +1,7 @@
+export interface CreateUserDto {
+  fullName: string;
+  email: string;
+  password: string;
+  phone: string;
+  address: string;
+}

--- a/backend/src/entities/Order.ts
+++ b/backend/src/entities/Order.ts
@@ -1,0 +1,28 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, CreateDateColumn, JoinColumn } from 'typeorm';
+import { Store } from './Store';
+import { OrderItem } from './OrderItem';
+
+@Entity({ name: 'orders' })
+export class Order {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'customer_name' })
+  customerName!: string;
+
+  @Column({ name: 'customer_phone', nullable: true })
+  customerPhone?: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @ManyToOne(() => Store, (store) => store.orders)
+  @JoinColumn({ name: 'store_id' })
+  store!: Store;
+
+  @Column({ name: 'store_id' })
+  storeId!: string;
+
+  @OneToMany(() => OrderItem, (item) => item.order, { cascade: true })
+  items!: OrderItem[];
+}

--- a/backend/src/entities/OrderItem.ts
+++ b/backend/src/entities/OrderItem.ts
@@ -1,0 +1,29 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { Order } from './Order';
+import { Product } from './Product';
+
+@Entity({ name: 'order_items' })
+export class OrderItem {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column('int')
+  quantity!: number;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  price!: number;
+
+  @ManyToOne(() => Order, (order) => order.items)
+  @JoinColumn({ name: 'order_id' })
+  order!: Order;
+
+  @Column({ name: 'order_id' })
+  orderId!: string;
+
+  @ManyToOne(() => Product)
+  @JoinColumn({ name: 'product_id' })
+  product!: Product;
+
+  @Column({ name: 'product_id' })
+  productId!: string;
+}

--- a/backend/src/entities/Product.ts
+++ b/backend/src/entities/Product.ts
@@ -1,0 +1,27 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { Store } from './Store';
+
+@Entity({ name: 'products' })
+export class Product {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  name!: string;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  price!: number;
+
+  @Column({ nullable: true })
+  category?: string;
+
+  @Column({ name: 'image_url', nullable: true })
+  imageUrl?: string;
+
+  @ManyToOne(() => Store, (store) => store.products)
+  @JoinColumn({ name: 'store_id' })
+  store!: Store;
+
+  @Column({ name: 'store_id' })
+  storeId!: string;
+}

--- a/backend/src/entities/Store.ts
+++ b/backend/src/entities/Store.ts
@@ -1,0 +1,36 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, OneToOne, JoinColumn } from 'typeorm';
+import { User } from './User';
+import { StoreSettings } from './StoreSettings';
+import { Product } from './Product';
+import { Order } from './Order';
+
+@Entity({ name: 'stores' })
+export class Store {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ unique: true })
+  slug!: string;
+
+  @Column()
+  name!: string;
+
+  @ManyToOne(() => User, (user) => user.stores)
+  @JoinColumn({ name: 'owner_id' })
+  owner!: User;
+
+  @Column({ name: 'owner_id' })
+  ownerId!: string;
+
+  @Column({ name: 'is_open', default: true })
+  isOpen!: boolean;
+
+  @OneToOne(() => StoreSettings, (settings) => settings.store, { cascade: true })
+  settings!: StoreSettings;
+
+  @OneToMany(() => Product, (product) => product.store)
+  products!: Product[];
+
+  @OneToMany(() => Order, (order) => order.store)
+  orders!: Order[];
+}

--- a/backend/src/entities/StoreSettings.ts
+++ b/backend/src/entities/StoreSettings.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToOne, JoinColumn } from 'typeorm';
+import { Store } from './Store';
+
+@Entity({ name: 'store_settings' })
+export class StoreSettings {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ nullable: true })
+  logoUrl?: string;
+
+  @Column({ name: 'primary_color', default: '#cc0000' })
+  primaryColor!: string;
+
+  @Column({ name: 'secondary_color', nullable: true })
+  secondaryColor?: string;
+
+  @OneToOne(() => Store, (store) => store.settings)
+  @JoinColumn({ name: 'store_id' })
+  store!: Store;
+
+  @Column()
+  storeId!: string;
+}

--- a/backend/src/entities/User.ts
+++ b/backend/src/entities/User.ts
@@ -1,0 +1,26 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { Store } from './Store';
+
+@Entity({ name: 'users' })
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'full_name' })
+  fullName!: string;
+
+  @Column({ unique: true })
+  email!: string;
+
+  @Column({ name: 'password_hash' })
+  passwordHash!: string;
+
+  @Column()
+  phone!: string;
+
+  @Column()
+  address!: string;
+
+  @OneToMany(() => Store, (store) => store.owner)
+  stores!: Store[];
+}

--- a/backend/src/repositories/OrderRepository.ts
+++ b/backend/src/repositories/OrderRepository.ts
@@ -1,0 +1,5 @@
+import { Repository } from 'typeorm';
+import { Order } from '../entities/Order';
+import { AppDataSource } from '../config/database';
+
+export const getOrderRepository = (): Repository<Order> => AppDataSource.getRepository(Order);

--- a/backend/src/repositories/ProductRepository.ts
+++ b/backend/src/repositories/ProductRepository.ts
@@ -1,0 +1,5 @@
+import { Repository } from 'typeorm';
+import { Product } from '../entities/Product';
+import { AppDataSource } from '../config/database';
+
+export const getProductRepository = (): Repository<Product> => AppDataSource.getRepository(Product);

--- a/backend/src/repositories/StoreRepository.ts
+++ b/backend/src/repositories/StoreRepository.ts
@@ -1,0 +1,5 @@
+import { Repository } from 'typeorm';
+import { Store } from '../entities/Store';
+import { AppDataSource } from '../config/database';
+
+export const getStoreRepository = (): Repository<Store> => AppDataSource.getRepository(Store);

--- a/backend/src/repositories/UserRepository.ts
+++ b/backend/src/repositories/UserRepository.ts
@@ -1,0 +1,5 @@
+import { Repository } from 'typeorm';
+import { User } from '../entities/User';
+import { AppDataSource } from '../config/database';
+
+export const getUserRepository = (): Repository<User> => AppDataSource.getRepository(User);

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,0 +1,26 @@
+import { Router } from 'express';
+import { AuthController } from '../controllers/AuthController';
+import { StoreController } from '../controllers/StoreController';
+import { ProductController } from '../controllers/ProductController';
+import { OrderController } from '../controllers/OrderController';
+
+const router = Router();
+const authController = new AuthController();
+const storeController = new StoreController();
+const productController = new ProductController();
+const orderController = new OrderController();
+
+router.post('/auth/register', (req, res) => authController.register(req, res));
+router.post('/auth/login', (req, res) => authController.login(req, res));
+
+router.get('/stores/:slug', (req, res) => storeController.getBySlug(req, res));
+router.put('/stores/:id', (req, res) => storeController.update(req, res));
+router.put('/stores/:id/status', (req, res) => storeController.setStatus(req, res));
+
+router.post('/stores/:storeId/products', (req, res) => productController.create(req, res));
+router.get('/stores/:storeId/products', (req, res) => productController.list(req, res));
+
+router.post('/stores/:storeId/orders', (req, res) => orderController.create(req, res));
+router.get('/stores/:storeId/orders', (req, res) => orderController.list(req, res));
+
+export default router;

--- a/backend/src/services/AuthService.ts
+++ b/backend/src/services/AuthService.ts
@@ -1,0 +1,23 @@
+import bcrypt from 'bcryptjs';
+import { getUserRepository } from '../repositories/UserRepository';
+import { CreateUserDto } from '../dto/CreateUserDto';
+import { User } from '../entities/User';
+
+export class AuthService {
+  async register(dto: CreateUserDto): Promise<User> {
+    const repo = getUserRepository();
+    const passwordHash = await bcrypt.hash(dto.password, 10);
+    const user = repo.create({
+      fullName: dto.fullName,
+      email: dto.email,
+      passwordHash,
+      phone: dto.phone,
+      address: dto.address,
+    });
+    return repo.save(user);
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    return getUserRepository().findOne({ where: { email } });
+  }
+}

--- a/backend/src/services/OrderService.ts
+++ b/backend/src/services/OrderService.ts
@@ -1,0 +1,38 @@
+import { CreateOrderDto } from '../dto/CreateOrderDto';
+import { getOrderRepository } from '../repositories/OrderRepository';
+import { getProductRepository } from '../repositories/ProductRepository';
+import { getStoreRepository } from '../repositories/StoreRepository';
+import { Order } from '../entities/Order';
+import { OrderItem } from '../entities/OrderItem';
+
+export class OrderService {
+  async create(storeId: string, dto: CreateOrderDto): Promise<Order> {
+    const store = await getStoreRepository().findOneByOrFail({ id: storeId });
+    const productRepo = getProductRepository();
+    const orderRepo = getOrderRepository();
+
+    const items: OrderItem[] = [];
+    for (const payload of dto.items) {
+      const product = await productRepo.findOneByOrFail({ id: payload.productId, storeId });
+      const item = new OrderItem();
+      item.product = product;
+      item.productId = product.id;
+      item.quantity = payload.quantity;
+      item.price = Number(product.price) * payload.quantity;
+      items.push(item);
+    }
+
+    const order = orderRepo.create({
+      customerName: dto.customerName,
+      customerPhone: dto.customerPhone,
+      store,
+      storeId: store.id,
+      items,
+    });
+    return orderRepo.save(order);
+  }
+
+  async list(storeId: string): Promise<Order[]> {
+    return getOrderRepository().find({ where: { storeId }, relations: ['items', 'items.product'] });
+  }
+}

--- a/backend/src/services/ProductService.ts
+++ b/backend/src/services/ProductService.ts
@@ -1,0 +1,17 @@
+import { CreateProductDto } from '../dto/CreateProductDto';
+import { getProductRepository } from '../repositories/ProductRepository';
+import { getStoreRepository } from '../repositories/StoreRepository';
+import { Product } from '../entities/Product';
+
+export class ProductService {
+  async create(storeId: string, dto: CreateProductDto): Promise<Product> {
+    const store = await getStoreRepository().findOneByOrFail({ id: storeId });
+    const repo = getProductRepository();
+    const product = repo.create({ ...dto, store, storeId: store.id });
+    return repo.save(product);
+  }
+
+  async listByStore(storeId: string): Promise<Product[]> {
+    return getProductRepository().find({ where: { storeId } });
+  }
+}

--- a/backend/src/services/StoreService.ts
+++ b/backend/src/services/StoreService.ts
@@ -1,0 +1,41 @@
+import slugify from 'slugify';
+import { CreateStoreDto } from '../dto/CreateStoreDto';
+import { getStoreRepository } from '../repositories/StoreRepository';
+import { getUserRepository } from '../repositories/UserRepository';
+import { Store } from '../entities/Store';
+import { StoreSettings } from '../entities/StoreSettings';
+
+export class StoreService {
+  async create(ownerId: string, dto: CreateStoreDto): Promise<Store> {
+    const storeRepo = getStoreRepository();
+    const user = await getUserRepository().findOneByOrFail({ id: ownerId });
+
+    const slug = dto.slug || slugify(dto.name, { lower: true, strict: true });
+    const store = storeRepo.create({
+      name: dto.name,
+      slug,
+      owner: user,
+      ownerId: user.id,
+      settings: new StoreSettings(),
+    });
+    store.settings.logoUrl = dto.logoUrl;
+    store.settings.primaryColor = dto.primaryColor;
+    store.settings.secondaryColor = dto.secondaryColor;
+    return storeRepo.save(store);
+  }
+
+  async update(storeId: string, payload: Partial<Store>): Promise<Store> {
+    const repo = getStoreRepository();
+    const store = await repo.findOneOrFail({ where: { id: storeId }, relations: ['settings'] });
+    repo.merge(store, payload);
+    return repo.save(store);
+  }
+
+  async toggleStatus(storeId: string, isOpen: boolean): Promise<Store> {
+    return this.update(storeId, { isOpen });
+  }
+
+  async findBySlug(slug: string): Promise<Store | null> {
+    return getStoreRepository().findOne({ where: { slug }, relations: ['settings'] });
+  }
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["src/**/*"]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "churrasco-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { apiFetch } from '../services/api';
+import '../styles/global.css';
+
+interface Product {
+  id: string;
+  name: string;
+  price: number;
+  category?: string;
+  imageUrl?: string;
+}
+
+export const AdminDashboard: React.FC<{ storeId: string }> = ({ storeId }) => {
+  const [products, setProducts] = useState<Product[]>([]);
+
+  useEffect(() => {
+    apiFetch(`/stores/${storeId}/products`).then(setProducts);
+  }, [storeId]);
+
+  return (
+    <div style={{ padding: 16 }}>
+      <header className="header">
+        <div>
+          <h2>Configurações da loja</h2>
+          <p>Gerencie identidade visual e cardápio.</p>
+        </div>
+        <button>Fechar loja</button>
+      </header>
+      <section>
+        <h3>Produtos</h3>
+        <ul>
+          {products.map((product) => (
+            <li key={product.id}>
+              {product.name} - R$ {product.price}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import '../styles/global.css';
+
+export const LandingPage: React.FC = () => (
+  <div>
+    <header className="header">
+      <div>
+        <strong>Churrasco SaaS</strong>
+        <p>Crie o seu site de pedidos em minutos.</p>
+      </div>
+      <button>Criar minha loja</button>
+    </header>
+    <main style={{ padding: '16px' }}>
+      <h1>Seu negócio, sua identidade</h1>
+      <p>Cadastre-se, personalize cores e logo, publique seu cardápio e receba pedidos online.</p>
+    </main>
+  </div>
+);
+
+export default LandingPage;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import { apiFetch } from '../services/api';
+
+export const Login: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const submit = async () => {
+    await apiFetch('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email, password }),
+    });
+  };
+
+  return (
+    <div style={{ padding: 16 }}>
+      <h2>Entrar</h2>
+      <input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+      <input placeholder="Senha" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+      <button onClick={submit}>Login</button>
+    </div>
+  );
+};
+
+export default Login;

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { apiFetch } from '../services/api';
+import '../styles/global.css';
+
+export const Register: React.FC = () => {
+  const [form, setForm] = useState({
+    fullName: '',
+    email: '',
+    password: '',
+    phone: '',
+    address: '',
+    storeName: '',
+    logoUrl: '',
+    primaryColor: '#c0392b',
+    secondaryColor: '#f39c12',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+    document.documentElement.style.setProperty('--primary-color', form.primaryColor);
+    document.documentElement.style.setProperty('--secondary-color', form.secondaryColor);
+  };
+
+  const submit = async () => {
+    await apiFetch('/auth/register', {
+      method: 'POST',
+      body: JSON.stringify(form),
+    });
+  };
+
+  return (
+    <div style={{ padding: 16 }}>
+      <h2>Cadastre sua loja</h2>
+      <div className="grid">
+        {Object.keys(form).map((key) => (
+          <input
+            key={key}
+            name={key}
+            placeholder={key}
+            value={(form as any)[key]}
+            onChange={handleChange}
+          />
+        ))}
+      </div>
+      <button onClick={submit}>Criar loja</button>
+    </div>
+  );
+};
+
+export default Register;

--- a/frontend/src/pages/StorePage.tsx
+++ b/frontend/src/pages/StorePage.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { apiFetch } from '../services/api';
+import '../styles/global.css';
+
+interface Store {
+  id: string;
+  name: string;
+  slug: string;
+  isOpen: boolean;
+  settings: { logoUrl?: string; primaryColor: string; secondaryColor?: string };
+}
+
+interface Product {
+  id: string;
+  name: string;
+  price: number;
+  category?: string;
+  imageUrl?: string;
+}
+
+export const StorePage: React.FC<{ slug: string }> = ({ slug }) => {
+  const [store, setStore] = useState<Store | null>(null);
+  const [products, setProducts] = useState<Product[]>([]);
+
+  useEffect(() => {
+    apiFetch(`/stores/${slug}`).then((data) => {
+      setStore(data);
+      if (data?.settings?.primaryColor) document.documentElement.style.setProperty('--primary-color', data.settings.primaryColor);
+      if (data?.settings?.secondaryColor) document.documentElement.style.setProperty('--secondary-color', data.settings.secondaryColor);
+      apiFetch(`/stores/${data.id}/products`).then(setProducts);
+    });
+  }, [slug]);
+
+  if (!store) return <p>Carregando...</p>;
+
+  return (
+    <div>
+      <header className="header">
+        <div>
+          {store.settings.logoUrl && <img src={store.settings.logoUrl} alt={store.name} style={{ height: 48 }} />}
+          <h1>{store.name}</h1>
+          <span>{store.isOpen ? 'Aberto' : 'Fechado'}</span>
+        </div>
+      </header>
+      <main style={{ padding: 16 }}>
+        <ul>
+          {products.map((product) => (
+            <li key={product.id} style={{ marginBottom: 8 }}>
+              <strong>{product.name}</strong> - R$ {product.price}
+              <button style={{ marginLeft: 8 }}>+</button>
+            </li>
+          ))}
+        </ul>
+      </main>
+    </div>
+  );
+};
+
+export default StorePage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,9 @@
+const BASE_URL = process.env.REACT_APP_API || 'http://localhost:3000';
+
+export async function apiFetch(path: string, options?: RequestInit) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options,
+  });
+  return res.json();
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,27 @@
+:root {
+  --primary-color: #c0392b;
+  --secondary-color: #f39c12;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  margin: 0;
+  background: #fafafa;
+  color: #222;
+}
+
+button {
+  background: var(--primary-color);
+  color: #fff;
+  padding: 12px 16px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+}

--- a/frontend/src/theme/colors.ts
+++ b/frontend/src/theme/colors.ts
@@ -1,0 +1,4 @@
+export const defaultTheme = {
+  primary: 'var(--primary-color, #c0392b)',
+  secondary: 'var(--secondary-color, #f39c12)',
+};


### PR DESCRIPTION
## Summary
- add Node.js TypeScript backend skeleton with TypeORM entities, DTOs, services, and controllers for multi-tenant stores
- include idempotent PostgreSQL schema script and configuration files
- scaffold frontend pages and theming to support multi-store landing, registration, admin, and store views

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69429d544dd4832d8db3bba0aaa82708)