### PR TITLE
Add docker compose and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,87 @@
 # Churrasquinho App
 
-Este repositório contém um esqueleto de aplicativo Flutter para controle de pedidos de espetinhos.
-Inclui filas de pedidos, alteração de status (entregue e pago) e armazenamento local em SQLite.
+Aplicação composta por um backend em Node.js/Express com TypeORM, um frontend em React + Vite e um esqueleto de aplicativo Flutter em `lib/`. O objetivo é gerenciar pedidos de espetinhos, produtos e lojas.
+
+## Visão geral da estrutura
+- `backend/`: API Express em TypeScript e integrações com PostgreSQL.
+- `frontend/`: SPA em React/Vite que consome a API.
+- `lib/`: protótipo Flutter (não integrado no fluxo descrito abaixo).
+- `docker-compose.yml`: orquestração opcional para subir banco, API e frontend via Docker.
+
+## Pré-requisitos
+Para execução local:
+- Node.js 20+ e npm
+- PostgreSQL 15+ (com extensão `pgcrypto` disponível)
+
+Para execução com contêineres:
+- Docker e Docker Compose
+
+## Configuração do banco de dados
+1. Crie o banco e habilite a extensão de UUID (apenas na primeira vez):
+   ```bash
+   createdb churrasco
+   psql -d churrasco -c 'CREATE EXTENSION IF NOT EXISTS "pgcrypto";'
+   ```
+2. Aplique o esquema presente em `backend/schema.sql`:
+   ```bash
+   psql -d churrasco -f backend/schema.sql
+   ```
+3. Ajuste as credenciais conforme necessário e reflita a URL na variável `DATABASE_URL` do backend (padrão: `postgres://postgres:postgres@localhost:5432/churrasco`).
+
+Para atualizar tabelas/índices futuramente, edite `backend/schema.sql` e reaplique o arquivo com o comando acima.
+
+## Executando o backend localmente
+1. Dentro de `backend/`, instale dependências:
+   ```bash
+   npm install
+   ```
+2. Crie um arquivo `.env` (opcional) para sobrepor valores padrão:
+   ```bash
+   DATABASE_URL=postgres://<usuario>:<senha>@localhost:5432/churrasco
+   PORT=3000
+   ```
+3. Suba a API:
+   ```bash
+   npm run start
+   ```
+4. A API ficará disponível em `http://localhost:3000`.
+
+## Executando o frontend localmente
+1. Dentro de `frontend/`, instale dependências:
+   ```bash
+   npm install
+   ```
+2. Caso deseje apontar para uma URL diferente da API, crie `.env` com `REACT_APP_API=http://localhost:3000`.
+3. Inicie o servidor de desenvolvimento Vite:
+   ```bash
+   npm run start
+   ```
+4. Acesse `http://localhost:5173` no navegador.
+
+## Execução completa via Docker Compose
+O arquivo `docker-compose.yml` sobe banco, backend e frontend em contêineres.
+
+1. Suba os serviços:
+   ```bash
+   docker compose up
+   ```
+2. Endereços padrão:
+   - API: `http://localhost:3000`
+   - Frontend: `http://localhost:5173`
+   - Banco: porta 5432 (credenciais padrão `postgres`/`postgres`).
+
+O schema do banco é aplicado automaticamente na primeira inicialização (montagem de `backend/schema.sql` em `/docker-entrypoint-initdb.d`). Caso altere o schema, derrube os contêineres e remova o volume `db_data` para reaplicar:
+```bash
+docker compose down -v
+docker compose up
+```
+
+## Ajustando credenciais e URLs
+- Backend: variáveis `DATABASE_URL` e `PORT` (arquivo `.env` ou variáveis de ambiente). O TypeORM busca a URL em `backend/src/config/env.ts`.
+- Frontend: variável `REACT_APP_API` define a URL base consumida em `frontend/src/services/api.ts`.
+- Docker Compose: atualize as variáveis do serviço `db` e refita `DATABASE_URL` no serviço `backend` e `REACT_APP_API` no `frontend` se mudar usuário/senha/host.
+
+## Dicas rápidas
+- As entidades TypeORM estão em `backend/src/entities/*` e compartilham o mesmo schema descrito em `backend/schema.sql`.
+- Não há migrações automáticas; use sempre o arquivo de schema para criar/atualizar tabelas.
+- O Flutter em `lib/` é apenas um esqueleto e não depende do backend/DB para ser executado.

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,11 +1,6 @@
-DO $$
-BEGIN
-   IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'churrasco') THEN
-      PERFORM dblink_exec('dbname=postgres', 'CREATE DATABASE churrasco');
-   END IF;
-EXCEPTION WHEN undefined_table THEN
-   -- dblink not installed, skip automatic database creation
-END$$;
+-- Database schema for Churrasquinho App
+-- Enable UUID generation helpers
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
 CREATE TABLE IF NOT EXISTS users (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.9'
+
+services:
+  db:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: churrasco
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+      - ./backend/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+
+  backend:
+    image: node:20
+    working_dir: /app
+    command: sh -c "npm install && npm run start"
+    volumes:
+      - ./backend:/app
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/churrasco
+      PORT: 3000
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+
+  frontend:
+    image: node:20
+    working_dir: /app
+    command: sh -c "npm install && npm run start -- --host 0.0.0.0 --port 5173"
+    volumes:
+      - ./frontend:/app
+    environment:
+      REACT_APP_API: http://localhost:3000
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend
+
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- rewrite README with detailed setup for backend, frontend, database, and Docker usage
- add docker-compose configuration to run Postgres, backend, and frontend together
- simplify database schema file and enable pgcrypto for UUID generation

## Testing
- not run (documentation and configuration only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69429fc70518832d88d020cffbb9d929)